### PR TITLE
add more config for the LDAP AUTH

### DIFF
--- a/gerrit-entrypoint.sh
+++ b/gerrit-entrypoint.sh
@@ -5,44 +5,44 @@ set -e
 if [ "$1" = '/var/gerrit/gerrit-start.sh' ]; then
   if [ -z "$(ls -A "$GERRIT_SITE")" ]; then
     echo "First time initialize gerrit..."
-    java -jar $GERRIT_WAR init --batch --no-auto-start -d $GERRIT_SITE
+    java -jar "${GERRIT_WAR}" init --batch --no-auto-start -d "${GERRIT_SITE}"
     #All-Projects.git must be removed here in order to be recreated at the secondary init below.
-    rm -rf $GERRIT_SITE/git/All-Projects.git 
+    rm -rf "${GERRIT_SITE}/git/All-Projects.git"
   fi
 
   #Customize gerrit.config
-  #mkdir $GERRIT_SITE/etc
+  #mkdir "${GERRIT_SITE}/etc"
 
   #Section gerrit
-  [ -z $WEBURL ] || git config -f $GERRIT_SITE/etc/gerrit.config gerrit.canonicalWebUrl $WEBURL
+  [ -z "${WEBURL}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" gerrit.canonicalWebUrl "${WEBURL}"
 
   #Section database
-  if [ $DATABASE_TYPE = 'postgresql' ]; then
-    git config -f $GERRIT_SITE/etc/gerrit.config database.type $DATABASE_TYPE
-    [ -z $DB_PORT_5432_TCP_ADDR ] || git config -f $GERRIT_SITE/etc/gerrit.config database.hostname $DB_PORT_5432_TCP_ADDR
-    [ -z $DB_PORT_5432_TCP_PORT ] || git config -f $GERRIT_SITE/etc/gerrit.config database.port $DB_PORT_5432_TCP_PORT
-    [ -z $DB_ENV_POSTGRES_DB ] || git config -f $GERRIT_SITE/etc/gerrit.config database.database $DB_ENV_POSTGRES_DB
-    [ -z $DB_ENV_POSTGRES_USER ] || git config -f $GERRIT_SITE/etc/gerrit.config database.username $DB_ENV_POSTGRES_USER
-    [ -z $DB_ENV_POSTGRES_PASSWORD ] || git config -f $GERRIT_SITE/etc/secure.config database.password $DB_ENV_POSTGRES_PASSWORD
+  if [ "${DATABASE_TYPE}" = 'postgresql' ]; then
+    git config -f "${GERRIT_SITE}/etc/gerrit.config" database.type "${DATABASE_TYPE}"
+    [ -z "${DB_PORT_5432_TCP_ADDR}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" database.hostname "${DB_PORT_5432_TCP_ADDR}"
+    [ -z "${DB_PORT_5432_TCP_PORT}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" database.port "${DB_PORT_5432_TCP_PORT}"
+    [ -z "${DB_ENV_POSTGRES_DB}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" database.database "${DB_ENV_POSTGRES_DB}"
+    [ -z "${DB_ENV_POSTGRES_USER}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" database.username "${DB_ENV_POSTGRES_USER}"
+    [ -z "${DB_ENV_POSTGRES_PASSWORD}" ] || git config -f "${GERRIT_SITE}/etc/secure.config" database.password "${DB_ENV_POSTGRES_PASSWORD}"
   fi
 
   #Section ldap
-  if [ $AUTH_TYPE = 'LDAP' ]; then
-    git config -f $GERRIT_SITE/etc/gerrit.config auth.type $AUTH_TYPE
-    [ -z $LDAP_HOST ] || git config -f $GERRIT_SITE/etc/gerrit.config ldap.server ldap://$LDAP_HOST
-    [ -z $LDAP_ACCOUNTBASE ] || git config -f $GERRIT_SITE/etc/gerrit.config ldap.accountBase $LDAP_ACCOUNTBASE
-    [ -z $LDAP_GROUPBASE ] || git config -f $GERRIT_SITE/etc/gerrit.config ldap.groupBase $LDAP_GROUPBASE
-    [ -z $LDAP_USER ] || git config -f $GERRIT_SITE/etc/gerrit.config ldap.user $LDAP_USER
-    [ -z $LDAP_PASSWORD ] || git config -f $GERRIT_SITE/etc/gerrit.config ldap.password $LDAP_PASSWORD
+  if [ "${AUTH_TYPE}" = 'LDAP' ]; then
+    git config -f "${GERRIT_SITE}/etc/gerrit.config" auth.type "${AUTH_TYPE}"
+    [ -z "${LDAP_HOST}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.server "ldap://${LDAP_HOST}"
+    [ -z "${LDAP_ACCOUNTBASE}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.accountBase "${LDAP_ACCOUNTBASE}"
+    [ -z "${LDAP_GROUPBASE}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.groupBase "${LDAP_GROUPBASE}"
+    [ -z "${LDAP_USER}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.user "${LDAP_USER}"
+    [ -z "${LDAP_PASSWORD}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.password "${LDAP_PASSWORD}"
   fi
 
   echo "Upgrading gerrit..."
-  java -jar $GERRIT_WAR init --batch -d $GERRIT_SITE
+  java -jar "${GERRIT_WAR}" init --batch -d "${GERRIT_SITE}"
   if [ $? -eq 0 ]; then
     echo "Upgrading is OK."
   else
     echo "Something wrong..."
-    cat $GERRIT_SITE/logs/error_log
+    cat "${GERRIT_SITE}/logs/error_log"
   fi
 fi
 exec "$@"

--- a/gerrit-entrypoint.sh
+++ b/gerrit-entrypoint.sh
@@ -29,8 +29,11 @@ if [ "$1" = '/var/gerrit/gerrit-start.sh' ]; then
   #Section ldap
   if [ $AUTH_TYPE = 'LDAP' ]; then
     git config -f $GERRIT_SITE/etc/gerrit.config auth.type $AUTH_TYPE
-    git config -f $GERRIT_SITE/etc/gerrit.config ldap.server ldap://$LDAP_HOST
-    git config -f $GERRIT_SITE/etc/gerrit.config ldap.accountBase $LDAP_ACCOUNTBASE
+    [ -z $LDAP_HOST ] || git config -f $GERRIT_SITE/etc/gerrit.config ldap.server ldap://$LDAP_HOST
+    [ -z $LDAP_ACCOUNTBASE ] || git config -f $GERRIT_SITE/etc/gerrit.config ldap.accountBase $LDAP_ACCOUNTBASE
+    [ -z $LDAP_GROUPBASE ] || git config -f $GERRIT_SITE/etc/gerrit.config ldap.groupBase $LDAP_GROUPBASE
+    [ -z $LDAP_USER ] || git config -f $GERRIT_SITE/etc/gerrit.config ldap.user $LDAP_USER
+    [ -z $LDAP_PASSWORD ] || git config -f $GERRIT_SITE/etc/gerrit.config ldap.password $LDAP_PASSWORD
   fi
 
   echo "Upgrading gerrit..."


### PR DESCRIPTION
Our LDAP server requires more config than then ones offered in the `gerrit-entrypoint.sh`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openfrontier/docker-gerrit/1)
<!-- Reviewable:end -->
